### PR TITLE
fix(auth): handle legacy Account.type with Better Auth

### DIFF
--- a/MIGRATE_TO_BETTER_AUTH.md
+++ b/MIGRATE_TO_BETTER_AUTH.md
@@ -199,6 +199,16 @@ Check provider callback URL config:
 
 - `https://your-domain.com/api/auth/callback/<provider>`
 
+### Error: `unable_to_create_user` with `Argument type is missing` on `Account`
+
+Cause:
+
+- legacy `Account.type` is still `NOT NULL` (Auth.js shape), but Better Auth does not write this column.
+
+Fix:
+
+- make `Account.type` nullable in Prisma schema and DB migration (`ALTER TABLE "Account" ALTER COLUMN "type" DROP NOT NULL`).
+
 ---
 
 ## 9) Post-cutover cleanup policy

--- a/prisma/migrations/20260313170000_make_account_type_nullable/migration.sql
+++ b/prisma/migrations/20260313170000_make_account_type_nullable/migration.sql
@@ -1,0 +1,2 @@
+-- Better Auth does not write legacy Account.type. Keep column for compatibility but make it nullable.
+ALTER TABLE "Account" ALTER COLUMN "type" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,7 +35,7 @@ model User {
 model Account {
   id                       String    @id @default(cuid()) @db.VarChar(191)
   userId                   String    @db.VarChar(191)
-  type                     String    @db.VarChar(191)
+  type                     String?   @db.VarChar(191)
   provider                 String    @db.VarChar(191)
   providerAccountId        String    @db.VarChar(191)
   refresh_token            String?   @db.Text

--- a/scripts/import-mysql-export-to-postgres.mjs
+++ b/scripts/import-mysql-export-to-postgres.mjs
@@ -104,7 +104,7 @@ const createSchemaStatements = [
     CREATE TABLE "Account" (
       "id" VARCHAR(191) PRIMARY KEY,
       "userId" VARCHAR(191) NOT NULL,
-      "type" VARCHAR(191) NOT NULL,
+      "type" VARCHAR(191),
       "provider" VARCHAR(191) NOT NULL,
       "providerAccountId" VARCHAR(191) NOT NULL,
       "refresh_token" TEXT,


### PR DESCRIPTION
## Summary
- make `Account.type` nullable in Prisma schema to match Better Auth account writes
- add Postgres migration to drop NOT NULL on `Account.type`
- align import script schema so recreated databases do not reintroduce `type NOT NULL`
- document the issue and fix in migration guide

## Validation
- `bunx prisma validate`
- `bun prisma generate`

## Context
This fixes user creation/account linking errors:
- `unable_to_create_user`
- `unable_to_link_account`
- `PrismaClientValidationError: Argument `type` is missing`
