### PR TITLE
Restore cover cache and blob reader images

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "scripts": {
     "gen:api": "bunx --bun orval --config ./orval.config.ts",
-    "dev": "bun --bun next dev",
-    "build": "bun --bun next build && serwist build",
+    "dev": "next dev",
+    "build": "next build && serwist build",
     "postbuild": "next-sitemap",
-    "start": "bun --bun next start -p 3636",
+    "start": "next start -p 3636",
     "upgrade": "next upgrade",
     "analyze": "next experimental-analyze",
     "lint": "eslint .",

--- a/src/app/(moetruyen)/moetruyen/(moe_reader)/_components/moe-manga-image.tsx
+++ b/src/app/(moetruyen)/moetruyen/(moe_reader)/_components/moe-manga-image.tsx
@@ -6,7 +6,7 @@ import type { PageState } from "@/hooks/use-reader-images";
 import { cn } from "@/lib/utils";
 import { getImageScaleClasses, useReaderStore } from "@/store/reader-store";
 import { RotateCcw } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 interface MoeMangaImageProps {
   page: PageState;
@@ -29,11 +29,8 @@ export default function MoeMangaImage({
 }: MoeMangaImageProps) {
   const scale = useReaderStore((state) => state.scale);
   const imgClasses = getImageScaleClasses(scale);
-  const [imgVisible, setImgVisible] = useState(false);
-
-  useEffect(() => {
-    setImgVisible(false);
-  }, [page.blob]);
+  const [visibleBlob, setVisibleBlob] = useState<string | null>(null);
+  const imgVisible = page.blob !== null && visibleBlob === page.blob;
 
   return (
     <div
@@ -59,12 +56,11 @@ export default function MoeMangaImage({
           loading="eager"
           onLoad={() => {
             onLoad(pageIndex);
-            setImgVisible(true);
+            setVisibleBlob(page.blob);
           }}
-          onError={(event) => {
+          onError={() => {
             onError(pageIndex);
-            event.currentTarget.src = "/images/xidoco.webp";
-            setImgVisible(true);
+            setVisibleBlob(null);
           }}
         />
       ) : null}

--- a/src/app/(reader)/_components/reader/manga-image.tsx
+++ b/src/app/(reader)/_components/reader/manga-image.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 import { RotateCcw } from "lucide-react";
 import { Spinner } from "@/components/ui/spinner";
 import { Button } from "@/components/ui/button";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 interface MangaImageProps {
   /** Trạng thái tải của trang này từ useReaderImages */
@@ -31,10 +31,8 @@ export default function MangaImage({
 }: MangaImageProps) {
   const scale = useReaderStore((s) => s.scale);
   const imgClasses = getImageScaleClasses(scale);
-  const [imgVisible, setImgVisible] = useState(false);
-  useEffect(() => {
-    setImgVisible(false);
-  }, [page.blob]);
+  const [visibleBlob, setVisibleBlob] = useState<string | null>(null);
+  const imgVisible = page.blob !== null && visibleBlob === page.blob;
 
   return (
     <div
@@ -60,12 +58,11 @@ export default function MangaImage({
           loading="eager"
           onLoad={() => {
             onLoad(pageIndex);
-            setImgVisible(true);
+            setVisibleBlob(page.blob);
           }}
-          onError={(e) => {
+          onError={() => {
             onError(pageIndex);
-            e.currentTarget.src = "/images/xidoco.webp";
-            setImgVisible(true);
+            setVisibleBlob(null);
           }}
         />
       )}

--- a/src/components/sw-registrar.tsx
+++ b/src/components/sw-registrar.tsx
@@ -8,7 +8,7 @@ export function ServiceWorkerRegistrar() {
       return;
 
     navigator.serviceWorker
-      .register("/sw.js", { scope: "/" })
+      .register("/sw.js", { scope: "/", updateViaCache: "none" })
       .catch((error) => {
         console.error(error);
       });

--- a/src/hooks/use-reader-images.ts
+++ b/src/hooks/use-reader-images.ts
@@ -1,11 +1,11 @@
 "use client";
 
 /**
- * `useReaderImages` - quản lý thứ tự kích hoạt ảnh reader qua URL trực tiếp.
+ * `useReaderImages` - tải ảnh reader bằng Blob URL.
  *
- * - Tối đa MAX_PARALLEL ảnh được kích hoạt tải đồng thời
+ * - Tối đa MAX_PARALLEL ảnh được fetch đồng thời
  * - Hàng đợi ưu tiên: trang hiện tại trước, rồi lan dần ra hai phía
- * - Reader component sẽ báo ngược lại khi ảnh load xong / lỗi
+ * - Fetch thành công tạo `blob:` URL; component vẫn báo ngược khi ảnh decode xong / lỗi
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -18,144 +18,356 @@ export interface PageState {
 }
 
 const MAX_PARALLEL = 3;
+const MAX_ATTEMPTS = 3;
+const RETRY_DELAY_MS = 3000;
+
+function createInitialPages(images: string[]): PageState[] {
+  return images.map(() => ({
+    blob: null,
+    isLoaded: false,
+    isLoading: false,
+    isFailed: false,
+  }));
+}
+
+function isBlobUrl(value: string | null): value is string {
+  return typeof value === "string" && value.startsWith("blob:");
+}
+
+function noopProcessQueue() {
+  return undefined;
+}
 
 export function useReaderImages(images: string[], currentIndex: number) {
   const [pages, setPages] = useState<PageState[]>(() =>
-    images.map(() => ({
-      blob: null,
-      isLoaded: false,
-      isLoading: false,
-      isFailed: false,
-    })),
+    createInitialPages(images),
   );
 
-  // Ref mirror của state - không cần re-render để đọc
   const stateRef = useRef<PageState[]>(pages);
   const parallelRef = useRef(0);
   const queueRef = useRef<number[]>([]);
   const mountedRef = useRef(true);
+  const controllersRef = useRef<Map<number, AbortController>>(new Map());
+  const pendingRetryRef = useRef<Set<number>>(new Set());
+  const retryTimeoutsRef = useRef<Map<number, ReturnType<typeof setTimeout>>>(
+    new Map(),
+  );
+  const attemptsRef = useRef<Map<number, number>>(new Map());
+  const requestTokensRef = useRef<Map<number, number>>(new Map());
+  const processQueueRef = useRef<() => void>(noopProcessQueue);
 
-  // Sync state → ref
   useEffect(() => {
     stateRef.current = pages;
   }, [pages]);
 
-  // ── Helpers ──────────────────────────────────────────────────────────────
-
   const updatePage = useCallback((index: number, patch: Partial<PageState>) => {
     if (!mountedRef.current) return;
-    setPages((prev) => {
-      const next = [...prev];
-      next[index] = { ...next[index], ...patch };
-      stateRef.current = next;
-      return next;
-    });
+
+    const current = stateRef.current;
+
+    if (!current[index]) return;
+
+    const next = [...current];
+    next[index] = { ...next[index], ...patch };
+    stateRef.current = next;
+    setPages(next);
   }, []);
 
-  // Xây hàng đợi ưu tiên quanh currentIndex
-  const buildQueue = useCallback(
-    (cIdx: number): number[] => {
-      const total = images.length;
-      const seen = new Set<number>();
-      const queue: number[] = [];
+  const revokePageBlob = useCallback((index: number) => {
+    const blobUrl = stateRef.current[index]?.blob ?? null;
 
-      const tryAdd = (i: number) => {
-        if (i < 0 || i >= total || seen.has(i)) return;
-        seen.add(i);
-        const st = stateRef.current[i];
-        if (!st.isLoaded && !st.isLoading && !st.isFailed) queue.push(i);
-      };
+    if (isBlobUrl(blobUrl)) {
+      URL.revokeObjectURL(blobUrl);
+    }
+  }, []);
 
-      tryAdd(cIdx);
-      for (let d = 1; d < total; d++) {
-        tryAdd(cIdx + d);
-        tryAdd(cIdx - d);
+  const clearRetryTimer = useCallback((index: number) => {
+    const timeout = retryTimeoutsRef.current.get(index);
+
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+      retryTimeoutsRef.current.delete(index);
+    }
+
+    pendingRetryRef.current.delete(index);
+  }, []);
+
+  const invalidateRequest = useCallback(
+    (index: number) => {
+      requestTokensRef.current.set(
+        index,
+        (requestTokensRef.current.get(index) ?? 0) + 1,
+      );
+      controllersRef.current.get(index)?.abort();
+      clearRetryTimer(index);
+    },
+    [clearRetryTimer],
+  );
+
+  const canStartLoad = useCallback((index: number) => {
+    const page = stateRef.current[index];
+
+    return (
+      !!page &&
+      !page.blob &&
+      !page.isLoaded &&
+      !page.isFailed &&
+      !controllersRef.current.has(index) &&
+      !pendingRetryRef.current.has(index)
+    );
+  }, []);
+
+  const enqueueIndex = useCallback(
+    (index: number, front = false) => {
+      if (index < 0 || index >= images.length) return;
+
+      queueRef.current = queueRef.current.filter((queued) => queued !== index);
+
+      if (front) {
+        queueRef.current.unshift(index);
+      } else {
+        queueRef.current.push(index);
       }
-      return queue;
     },
     [images.length],
   );
 
-  // ── Core activator ───────────────────────────────────────────────────────
+  const loadPage = useCallback(
+    async (index: number) => {
+      const source = images[index];
+
+      if (!source) {
+        updatePage(index, {
+          blob: null,
+          isFailed: true,
+          isLoaded: false,
+          isLoading: false,
+        });
+        parallelRef.current = Math.max(0, parallelRef.current - 1);
+        processQueueRef.current();
+        return;
+      }
+
+      const token = (requestTokensRef.current.get(index) ?? 0) + 1;
+      requestTokensRef.current.set(index, token);
+
+      const controller = new AbortController();
+      controllersRef.current.set(index, controller);
+
+      const attempt = (attemptsRef.current.get(index) ?? 0) + 1;
+      attemptsRef.current.set(index, attempt);
+
+      updatePage(index, {
+        isFailed: false,
+        isLoaded: false,
+        isLoading: true,
+      });
+
+      try {
+        const response = await fetch(source, { signal: controller.signal });
+
+        if (!response.ok) {
+          throw new Error(`Failed to fetch reader image: ${response.status}`);
+        }
+
+        const blob = await response.blob();
+
+        if (
+          !mountedRef.current ||
+          requestTokensRef.current.get(index) !== token
+        ) {
+          return;
+        }
+
+        const blobUrl = URL.createObjectURL(blob);
+        revokePageBlob(index);
+        attemptsRef.current.delete(index);
+
+        updatePage(index, {
+          blob: blobUrl,
+          isFailed: false,
+          isLoaded: false,
+          isLoading: false,
+        });
+      } catch {
+        if (
+          controller.signal.aborted ||
+          !mountedRef.current ||
+          requestTokensRef.current.get(index) !== token
+        ) {
+          return;
+        }
+
+        if (attempt < MAX_ATTEMPTS) {
+          pendingRetryRef.current.add(index);
+
+          const timeout = setTimeout(() => {
+            retryTimeoutsRef.current.delete(index);
+            pendingRetryRef.current.delete(index);
+
+            if (!mountedRef.current) return;
+
+            enqueueIndex(index, true);
+            processQueueRef.current();
+          }, RETRY_DELAY_MS);
+
+          retryTimeoutsRef.current.set(index, timeout);
+          return;
+        }
+
+        attemptsRef.current.delete(index);
+        revokePageBlob(index);
+
+        updatePage(index, {
+          blob: null,
+          isFailed: true,
+          isLoaded: false,
+          isLoading: false,
+        });
+      } finally {
+        if (controllersRef.current.get(index) === controller) {
+          controllersRef.current.delete(index);
+        }
+
+        parallelRef.current = Math.max(0, parallelRef.current - 1);
+
+        if (mountedRef.current) {
+          processQueueRef.current();
+        }
+      }
+    },
+    [enqueueIndex, images, revokePageBlob, updatePage],
+  );
 
   const processQueue = useCallback(() => {
     while (queueRef.current.length > 0 && parallelRef.current < MAX_PARALLEL) {
-      const idx = queueRef.current.shift()!;
-      const page = stateRef.current[idx];
-      if (!page || page.isLoaded || page.isLoading || page.isFailed) continue;
+      const index = queueRef.current.shift()!;
 
-      parallelRef.current++;
-      updatePage(idx, {
-        blob: images[idx],
-        isLoading: true,
-        isLoaded: false,
-        isFailed: false,
-      });
+      if (!canStartLoad(index)) continue;
+
+      parallelRef.current += 1;
+      void loadPage(index);
     }
-  }, [images, updatePage]);
-
-  // ── Rebuild queue khi currentIndex thay đổi ──────────────────────────────
+  }, [canStartLoad, loadPage]);
 
   useEffect(() => {
-    // Thêm vào đầu queue các trang chưa load quanh currentIndex
+    processQueueRef.current = processQueue;
+  }, [processQueue]);
+
+  const buildQueue = useCallback(
+    (centerIndex: number): number[] => {
+      const total = images.length;
+      const seen = new Set<number>();
+      const queue: number[] = [];
+
+      const tryAdd = (index: number) => {
+        if (index < 0 || index >= total || seen.has(index)) return;
+
+        seen.add(index);
+
+        if (canStartLoad(index)) {
+          queue.push(index);
+        }
+      };
+
+      tryAdd(centerIndex);
+
+      for (let distance = 1; distance < total; distance++) {
+        tryAdd(centerIndex + distance);
+        tryAdd(centerIndex - distance);
+      }
+
+      return queue;
+    },
+    [canStartLoad, images.length],
+  );
+
+  useEffect(() => {
     const priority = buildQueue(currentIndex);
-    // Giữ lại những trang đang trong queue cũ nhưng không trùng
-    const existingSet = new Set(priority);
+    const prioritySet = new Set(priority);
     const remaining = queueRef.current.filter(
-      (i) => !existingSet.has(i) && !stateRef.current[i]?.isLoaded,
+      (index) => !prioritySet.has(index) && canStartLoad(index),
     );
+
     queueRef.current = [...priority, ...remaining];
     processQueue();
-  }, [currentIndex, buildQueue, processQueue]);
-
-  // ── Retry thủ công ───────────────────────────────────────────────────────
+  }, [buildQueue, canStartLoad, currentIndex, processQueue]);
 
   const retry = useCallback(
     (index: number) => {
+      if (!stateRef.current[index]) return;
+
+      invalidateRequest(index);
+      attemptsRef.current.delete(index);
+      revokePageBlob(index);
+
       updatePage(index, {
         blob: null,
         isFailed: false,
-        isLoading: false,
         isLoaded: false,
+        isLoading: false,
       });
-      queueRef.current.unshift(index);
-      processQueue();
+
+      enqueueIndex(index, true);
+      processQueueRef.current();
     },
-    [updatePage, processQueue],
+    [enqueueIndex, invalidateRequest, revokePageBlob, updatePage],
   );
 
   const markLoaded = useCallback(
     (index: number) => {
       const page = stateRef.current[index];
-      if (!mountedRef.current || !page || !page.isLoading) return;
 
-      parallelRef.current = Math.max(0, parallelRef.current - 1);
+      if (!mountedRef.current || !page?.blob || page.isFailed) return;
+
       updatePage(index, { isLoaded: true, isLoading: false });
-      processQueue();
     },
-    [processQueue, updatePage],
+    [updatePage],
   );
 
   const markFailed = useCallback(
     (index: number) => {
       const page = stateRef.current[index];
-      if (!mountedRef.current || !page || !page.isLoading) return;
 
-      parallelRef.current = Math.max(0, parallelRef.current - 1);
-      updatePage(index, { isFailed: true, isLoading: false });
-      processQueue();
+      if (!mountedRef.current || !page || page.isFailed) return;
+
+      invalidateRequest(index);
+      attemptsRef.current.delete(index);
+      revokePageBlob(index);
+
+      updatePage(index, {
+        blob: null,
+        isFailed: true,
+        isLoaded: false,
+        isLoading: false,
+      });
+
+      processQueueRef.current();
     },
-    [processQueue, updatePage],
+    [invalidateRequest, revokePageBlob, updatePage],
   );
-
-  // ── Cleanup ──────────────────────────────────────────────────────────────
 
   useEffect(() => {
     mountedRef.current = true;
+    const controllers = controllersRef.current;
+    const retryTimeouts = retryTimeoutsRef.current;
+    const pendingRetries = pendingRetryRef.current;
+
     return () => {
       mountedRef.current = false;
+
+      controllers.forEach((controller) => controller.abort());
+      controllers.clear();
+
+      retryTimeouts.forEach((timeout) => clearTimeout(timeout));
+      retryTimeouts.clear();
+      pendingRetries.clear();
+
+      stateRef.current.forEach((_, index) => {
+        revokePageBlob(index);
+      });
     };
-  }, []);
+  }, [revokePageBlob]);
 
   return { pages, retry, markLoaded, markFailed };
 }

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -3,7 +3,13 @@
 /// <reference lib="webworker" />
 import { defaultCache } from "@serwist/next/worker";
 import type { PrecacheEntry, SerwistGlobalConfig } from "serwist";
-import { NetworkOnly, Serwist } from "serwist";
+import {
+  CacheableResponsePlugin,
+  CacheFirst,
+  ExpirationPlugin,
+  NetworkOnly,
+  Serwist,
+} from "serwist";
 
 declare global {
   interface WorkerGlobalScope extends SerwistGlobalConfig {
@@ -13,12 +19,45 @@ declare global {
 
 declare const self: ServiceWorkerGlobalScope;
 
+const COVER_CACHE_MAX_AGE_SECONDS = 7 * 24 * 60 * 60;
+
+const coverCachePlugins = [
+  new CacheableResponsePlugin({
+    statuses: [0, 200],
+  }),
+  new ExpirationPlugin({
+    maxEntries: 500,
+    maxAgeSeconds: COVER_CACHE_MAX_AGE_SECONDS,
+    purgeOnQuotaError: true,
+  }),
+];
+
 const serwist = new Serwist({
   precacheEntries: self.__SW_MANIFEST,
   skipWaiting: true,
   clientsClaim: true,
   navigationPreload: true,
   runtimeCaching: [
+    {
+      matcher: ({ url }) =>
+        url.protocol === "https:" &&
+        url.hostname === "i.suicaodex.com" &&
+        url.pathname.startsWith("/covers/"),
+      handler: new CacheFirst({
+        cacheName: "suicaodex-cover-images",
+        plugins: coverCachePlugins,
+      }),
+    },
+    {
+      matcher: ({ url }) =>
+        url.protocol === "https:" &&
+        url.hostname === "u.truyen.moe" &&
+        url.pathname.startsWith("/uploads/covers/"),
+      handler: new CacheFirst({
+        cacheName: "truyen-moe-cover-images",
+        plugins: coverCachePlugins,
+      }),
+    },
     // Không cache API calls từ weebdex
     {
       matcher: ({ url }) => url.hostname === "wd.suicaodex.com",


### PR DESCRIPTION
Summary: restore dedicated service worker caches for SuicaoDex and legacy Truyen Moe cover images, limit each cover cache to 500 entries for 7 days, restore reader image loading through fetch plus Blob object URLs for both readers, and keep reader image failures in retry state instead of falling back to a cover image. Verification: targeted eslint on changed files passed; bun run build passed.