### PR TITLE
fix(sw): prevent opaque cover cache bloat

### DIFF
--- a/src/app/(moetruyen)/moetruyen/(moe_home)/(scanlation)/group/[id]/[[...slug]]/_components/group-manga-card.tsx
+++ b/src/app/(moetruyen)/moetruyen/(moe_home)/(scanlation)/group/[id]/[[...slug]]/_components/group-manga-card.tsx
@@ -29,6 +29,7 @@ export default function GroupMangaCard({ manga }: GroupMangaCardProps) {
               "h-auto w-full rounded-sm block object-cover aspect-5/7",
             )}
             src={coverUrl}
+            crossOrigin="anonymous"
             alt={`Ảnh bìa ${manga.title}`}
             onError={(e) => {
               e.currentTarget.src = "/images/xidoco.webp";

--- a/src/app/(moetruyen)/moetruyen/(moe_home)/_components/moe_latest-update/moe-latest-manga-card.tsx
+++ b/src/app/(moetruyen)/moetruyen/(moe_home)/_components/moe_latest-update/moe-latest-manga-card.tsx
@@ -32,6 +32,7 @@ export default function MoeLatestMangaCard({ manga }: MoeLatestMangaCardProps) {
           <LazyLoadImage
             wrapperClassName="block! w-full h-full absolute inset-0"
             src={coverUrl}
+            crossOrigin="anonymous"
             alt={manga.title}
             placeholderSrc="/images/place-doro.webp"
             className="w-full h-full object-cover"

--- a/src/app/(moetruyen)/moetruyen/(moe_home)/_components/moe_leaderboard/moe-leaderboard-item.tsx
+++ b/src/app/(moetruyen)/moetruyen/(moe_home)/_components/moe_leaderboard/moe-leaderboard-item.tsx
@@ -49,6 +49,7 @@ export default function MoeLeaderboardItem({
           <LazyLoadImage
             wrapperClassName="block! absolute inset-0 h-full w-full"
             src={coverUrl}
+            crossOrigin="anonymous"
             alt={manga.title}
             placeholderSrc={FALLBACK_COVER}
             className="h-full w-full object-cover"

--- a/src/app/(moetruyen)/moetruyen/(moe_home)/_components/moe_popular-manga/moe_manga-slide.tsx
+++ b/src/app/(moetruyen)/moetruyen/(moe_home)/_components/moe_popular-manga/moe_manga-slide.tsx
@@ -104,6 +104,7 @@ export default function MoeMangaSlide({
           <LazyLoadImage
             placeholderSrc={FALLBACK_COVER}
             src={thumbnailCoverUrl}
+            crossOrigin="anonymous"
             alt={`Ảnh bìa ${manga.title}`}
             onError={(event) => {
               event.currentTarget.src = FALLBACK_COVER;
@@ -130,8 +131,7 @@ export default function MoeMangaSlide({
 
           <div className="hidden md:flex flex-wrap gap-1">
             <MoeStatusTag status={manga.status} />
-            {manga.genres &&
-              manga.genres.map((genre) => (
+            {manga.genres?.map((genre) => (
                 <MoeNormalTag key={genre.id} className="uppercase">
                   {genre.name}
                 </MoeNormalTag>

--- a/src/app/(moetruyen)/moetruyen/(moe_home)/manga/_components/moe-manga-cover.tsx
+++ b/src/app/(moetruyen)/moetruyen/(moe_home)/manga/_components/moe-manga-cover.tsx
@@ -54,6 +54,7 @@ export default function MoeMangaCover({
               </div>
               <LazyLoadImage
                 src={coverUrl}
+                crossOrigin="anonymous"
                 alt={`Ảnh bìa ${alt}`}
                 className="z-20 max-h-full max-w-full object-cover"
                 visibleByDefault
@@ -74,6 +75,7 @@ export default function MoeMangaCover({
         )}
         placeholderSrc={placeholder}
         src={thumbnailCoverUrl}
+        crossOrigin="anonymous"
         alt={`Ảnh bìa ${alt}`}
         className={cn("block h-auto w-full rounded-sm", className)}
         onLoad={() => setLoaded(true)}

--- a/src/app/(suicaodex)/(home)/_components/latest-update/latest-manga-card.tsx
+++ b/src/app/(suicaodex)/(home)/_components/latest-update/latest-manga-card.tsx
@@ -40,6 +40,7 @@ export default function LatestMangaCard({ chapter }: LatestMangaCardProps) {
           <LazyLoadImage
             wrapperClassName="block! w-full h-full absolute inset-0"
             src={coverUrl}
+            crossOrigin="anonymous"
             alt={title}
             placeholderSrc="/images/place-doro.webp"
             className="w-full h-full object-cover"

--- a/src/app/(suicaodex)/(home)/_components/moetruyen-section/index.tsx
+++ b/src/app/(suicaodex)/(home)/_components/moetruyen-section/index.tsx
@@ -148,6 +148,7 @@ function RotatingBackground({
           >
             <LazyLoadImage
               src={coverUrl}
+              crossOrigin="anonymous"
               alt={manga.title}
               wrapperClassName="block! absolute inset-0 h-full w-full overflow-hidden rounded-md"
               placeholderSrc={FALLBACK_COVER}

--- a/src/app/(suicaodex)/(manga)/manga/_components/manga-card.tsx
+++ b/src/app/(suicaodex)/(manga)/manga/_components/manga-card.tsx
@@ -46,6 +46,7 @@ export default function MangaCard({
             "h-auto w-full rounded-sm block object-cover aspect-5/7",
           )}
           src={cover_url}
+          crossOrigin="anonymous"
           alt={`Ảnh bìa ${title}`}
           onLoad={() => setLoaded(true)}
           onError={(e) => {

--- a/src/app/(suicaodex)/(manga)/manga/_components/manga-cover.tsx
+++ b/src/app/(suicaodex)/(manga)/manga/_components/manga-cover.tsx
@@ -81,6 +81,7 @@ export default function MangaCover({
               </div>
               <img
                 src={cover_full}
+                crossOrigin="anonymous"
                 alt={`Ảnh bìa ${alt}`}
                 className="max-h-full max-w-full object-cover z-20"
                 fetchPriority="high"
@@ -102,6 +103,7 @@ export default function MangaCover({
         placeholderSrc={placeholder}
         className={cn("h-auto w-full rounded-sm block", className)}
         src={cover_url}
+        crossOrigin="anonymous"
         alt={`Ảnh bìa ${alt}`}
         onLoad={() => setLoaded(true)}
         visibleByDefault={preload}

--- a/src/app/(suicaodex)/(user)/history/_components/history-manga-card.tsx
+++ b/src/app/(suicaodex)/(user)/history/_components/history-manga-card.tsx
@@ -54,6 +54,7 @@ export default function HistoryMangaCard({
       <NoPrefetchLink href={mangaHref} className="shrink-0">
         <Image
           src={coverUrl}
+          crossOrigin="anonymous"
           alt={title}
           width={80}
           height={112}

--- a/src/app/(suicaodex)/(user)/my-library/_components/account-library-card.tsx
+++ b/src/app/(suicaodex)/(user)/my-library/_components/account-library-card.tsx
@@ -52,12 +52,12 @@ export default function AccountLibraryCard({
         toast.error(`Lỗi API: ${res.status}`);
         return;
       }
-      const manga: MangaListItem = await res.json();
+      const manga = (await res.json()) as MangaListItem;
       const { title: newTitle } = parseMangaTitle(manga);
-      const newCoverId = (manga as any).relationships?.cover?.id ?? null;
+      const newCoverId = manga.relationships?.cover?.id ?? null;
 
       // Lưu vào DB (background, không cần await để UI phản hồi ngay)
-      saveMangaMetadata(session.user.id, id, newTitle, newCoverId);
+      void saveMangaMetadata(session.user.id, id, newTitle, newCoverId);
 
       onRefreshed?.(id, newTitle, newCoverId);
       toast.success("Đã cập nhật thông tin truyện!");
@@ -96,6 +96,7 @@ export default function AccountLibraryCard({
             placeholderSrc="/images/place-doro.webp"
             className="w-full h-auto aspect-5/7 object-cover rounded-sm"
             src={coverUrl}
+            crossOrigin="anonymous"
             alt={`Ảnh bìa ${displayTitle}`}
             onError={(e) => {
               e.currentTarget.src = "/images/xidoco.webp";
@@ -115,7 +116,9 @@ export default function AccountLibraryCard({
         variant="secondary"
         size="icon-sm"
         className="absolute top-1 left-1 size-6"
-        onClick={handleRefresh}
+        onClick={(event) => {
+          void handleRefresh(event);
+        }}
         disabled={isRefreshing}
         aria-label="Cập nhật thông tin truyện"
       >
@@ -129,7 +132,9 @@ export default function AccountLibraryCard({
         variant="destructive"
         size="icon-sm"
         className="absolute top-1 right-1 size-6"
-        onClick={handleRemove}
+        onClick={(event) => {
+          void handleRemove(event);
+        }}
         disabled={isRemoving}
         aria-label="Xóa khỏi thư viện"
       >

--- a/src/app/(suicaodex)/(user)/my-library/_components/library-manga-card.tsx
+++ b/src/app/(suicaodex)/(user)/my-library/_components/library-manga-card.tsx
@@ -34,6 +34,7 @@ export default function LibraryMangaCard({
             placeholderSrc="/images/place-doro.webp"
             className="w-full h-auto aspect-5/7 object-cover rounded-sm"
             src={coverUrl}
+            crossOrigin="anonymous"
             alt={`Ảnh bìa ${title}`}
             onError={(e) => {
               e.currentTarget.src = "/images/xidoco.webp";

--- a/src/components/search/compact-card-moetruyen.tsx
+++ b/src/components/search/compact-card-moetruyen.tsx
@@ -26,6 +26,7 @@ export default function CompactCardMoetruyen({
         <LazyLoadImage
           wrapperClassName="block! shrink-0"
           src={coverUrl}
+          crossOrigin="anonymous"
           alt={manga.title}
           placeholderSrc="/images/place-doro.webp"
           className="w-16! h-auto! aspect-5/7 object-cover! rounded-sm border"

--- a/src/components/search/compact-card-weebdex.tsx
+++ b/src/components/search/compact-card-weebdex.tsx
@@ -27,6 +27,7 @@ export default function CompactCardWeebdex({ manga }: CompactCardWeebdexProps) {
         <LazyLoadImage
           wrapperClassName="block! shrink-0"
           src={coverUrl}
+          crossOrigin="anonymous"
           alt={title}
           placeholderSrc="/images/place-doro.webp"
           className="w-16! h-auto! aspect-5/7 object-cover! rounded-sm border"

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -24,6 +24,11 @@ const COVER_CACHE_MAX_AGE_SECONDS = 7 * 24 * 60 * 60;
 const SUICAODEX_COVER_CACHE_NAME = "suicaodex-cover-images";
 const TRUYEN_MOE_COVER_CACHE_NAME = "truyen-moe-cover-images";
 const LEGACY_COVER_CACHE_NAMES = ["moetruyen-cover-images"] as const;
+const DEFAULT_IMAGE_CACHE_NAMES = [
+  "next-image",
+  "cross-origin",
+  "static-image-assets",
+] as const;
 
 function isSuicaodex512CoverUrl(url: URL) {
   return (
@@ -40,22 +45,59 @@ async function deleteLegacyCoverCaches() {
   );
 }
 
-async function pruneSuicaodexCoverCache(existingCacheNames: string[]) {
-  if (!existingCacheNames.includes(SUICAODEX_COVER_CACHE_NAME)) return;
+async function deleteDefaultImageCaches() {
+  await Promise.all(
+    DEFAULT_IMAGE_CACHE_NAMES.map((cacheName) => caches.delete(cacheName)),
+  );
+}
 
-  const cache = await caches.open(SUICAODEX_COVER_CACHE_NAME);
+async function pruneCoverCache(
+  cacheName: string,
+  existingCacheNames: string[],
+  isAllowedUrl: (url: URL) => boolean,
+) {
+  if (!existingCacheNames.includes(cacheName)) return;
+
+  const cache = await caches.open(cacheName);
   const requests = await cache.keys();
 
   await Promise.all(
-    requests.map((request) => {
+    requests.map(async (request) => {
       const url = new URL(request.url);
 
-      if (isSuicaodex512CoverUrl(url)) {
-        return Promise.resolve(false);
+      if (!isAllowedUrl(url)) {
+        return cache.delete(request);
       }
 
-      return cache.delete(request);
+      const response = await cache.match(request);
+
+      if (response?.type === "opaque") {
+        return cache.delete(request);
+      }
+
+      return false;
     }),
+  );
+}
+
+async function pruneSuicaodexCoverCache(existingCacheNames: string[]) {
+  if (!existingCacheNames.includes(SUICAODEX_COVER_CACHE_NAME)) return;
+
+  await pruneCoverCache(
+    SUICAODEX_COVER_CACHE_NAME,
+    existingCacheNames,
+    isSuicaodex512CoverUrl,
+  );
+}
+
+async function pruneTruyenMoeCoverCache(existingCacheNames: string[]) {
+  await pruneCoverCache(
+    TRUYEN_MOE_COVER_CACHE_NAME,
+    existingCacheNames,
+    (url) =>
+      url.protocol === "https:" &&
+      url.hostname === "u.truyen.moe" &&
+      url.pathname.startsWith("/uploads/covers/"),
   );
 }
 
@@ -74,11 +116,12 @@ async function deleteOversizedCoverCache(
 }
 
 async function cleanupCoverCaches() {
-  await deleteLegacyCoverCaches();
+  await Promise.all([deleteLegacyCoverCaches(), deleteDefaultImageCaches()]);
 
   const existingCacheNames = await caches.keys();
 
   await pruneSuicaodexCoverCache(existingCacheNames);
+  await pruneTruyenMoeCoverCache(existingCacheNames);
   await Promise.all(
     [SUICAODEX_COVER_CACHE_NAME, TRUYEN_MOE_COVER_CACHE_NAME].map(
       (cacheName) => deleteOversizedCoverCache(cacheName, existingCacheNames),
@@ -88,7 +131,7 @@ async function cleanupCoverCaches() {
 
 const coverCachePlugins = [
   new CacheableResponsePlugin({
-    statuses: [0, 200],
+    statuses: [200],
   }),
   new ExpirationPlugin({
     maxEntries: COVER_CACHE_MAX_ENTRIES,
@@ -104,14 +147,16 @@ const serwist = new Serwist({
   navigationPreload: true,
   runtimeCaching: [
     {
-      matcher: ({ url }) => isSuicaodex512CoverUrl(url),
+      matcher: ({ request, url }) =>
+        request.mode === "cors" && isSuicaodex512CoverUrl(url),
       handler: new CacheFirst({
         cacheName: SUICAODEX_COVER_CACHE_NAME,
         plugins: coverCachePlugins,
       }),
     },
     {
-      matcher: ({ url }) =>
+      matcher: ({ request, url }) =>
+        request.mode === "cors" &&
         url.protocol === "https:" &&
         url.hostname === "u.truyen.moe" &&
         url.pathname.startsWith("/uploads/covers/"),
@@ -119,6 +164,14 @@ const serwist = new Serwist({
         cacheName: TRUYEN_MOE_COVER_CACHE_NAME,
         plugins: coverCachePlugins,
       }),
+    },
+    // Chặn defaultCache của Serwist cache ảnh tối ưu Next và ảnh cross-origin
+    // ngoài các cover cache chủ đích ở trên; các cache này dễ phình rất lớn.
+    {
+      matcher: ({ request, sameOrigin, url }) =>
+        request.destination === "image" &&
+        (url.pathname === "/_next/image" || !sameOrigin),
+      handler: new NetworkOnly(),
     },
     // Không cache API calls từ weebdex
     {


### PR DESCRIPTION
## Summary
- cache cover images only when the request is CORS-enabled and the response is cacheable as status 200
- add crossOrigin=anonymous to cover image renders that should participate in SW cover caching
- clean up legacy/default image caches and remove old opaque cover entries on SW activate

## Verification
- targeted ESLint on changed files passed
- bun run build passed
- git diff --check passed