### PR TITLE
fix(sw): avoid cors-blocked cover loads

### DIFF
--- a/src/app/(moetruyen)/moetruyen/(moe_home)/(scanlation)/group/[id]/[[...slug]]/_components/group-manga-card.tsx
+++ b/src/app/(moetruyen)/moetruyen/(moe_home)/(scanlation)/group/[id]/[[...slug]]/_components/group-manga-card.tsx
@@ -29,7 +29,6 @@ export default function GroupMangaCard({ manga }: GroupMangaCardProps) {
               "h-auto w-full rounded-sm block object-cover aspect-5/7",
             )}
             src={coverUrl}
-            crossOrigin="anonymous"
             alt={`Ảnh bìa ${manga.title}`}
             onError={(e) => {
               e.currentTarget.src = "/images/xidoco.webp";

--- a/src/app/(moetruyen)/moetruyen/(moe_home)/_components/moe_latest-update/moe-latest-manga-card.tsx
+++ b/src/app/(moetruyen)/moetruyen/(moe_home)/_components/moe_latest-update/moe-latest-manga-card.tsx
@@ -32,7 +32,6 @@ export default function MoeLatestMangaCard({ manga }: MoeLatestMangaCardProps) {
           <LazyLoadImage
             wrapperClassName="block! w-full h-full absolute inset-0"
             src={coverUrl}
-            crossOrigin="anonymous"
             alt={manga.title}
             placeholderSrc="/images/place-doro.webp"
             className="w-full h-full object-cover"

--- a/src/app/(moetruyen)/moetruyen/(moe_home)/_components/moe_leaderboard/moe-leaderboard-item.tsx
+++ b/src/app/(moetruyen)/moetruyen/(moe_home)/_components/moe_leaderboard/moe-leaderboard-item.tsx
@@ -49,7 +49,6 @@ export default function MoeLeaderboardItem({
           <LazyLoadImage
             wrapperClassName="block! absolute inset-0 h-full w-full"
             src={coverUrl}
-            crossOrigin="anonymous"
             alt={manga.title}
             placeholderSrc={FALLBACK_COVER}
             className="h-full w-full object-cover"

--- a/src/app/(moetruyen)/moetruyen/(moe_home)/_components/moe_popular-manga/moe_manga-slide.tsx
+++ b/src/app/(moetruyen)/moetruyen/(moe_home)/_components/moe_popular-manga/moe_manga-slide.tsx
@@ -104,7 +104,6 @@ export default function MoeMangaSlide({
           <LazyLoadImage
             placeholderSrc={FALLBACK_COVER}
             src={thumbnailCoverUrl}
-            crossOrigin="anonymous"
             alt={`Ảnh bìa ${manga.title}`}
             onError={(event) => {
               event.currentTarget.src = FALLBACK_COVER;

--- a/src/app/(moetruyen)/moetruyen/(moe_home)/manga/_components/moe-manga-cover.tsx
+++ b/src/app/(moetruyen)/moetruyen/(moe_home)/manga/_components/moe-manga-cover.tsx
@@ -54,7 +54,6 @@ export default function MoeMangaCover({
               </div>
               <LazyLoadImage
                 src={coverUrl}
-                crossOrigin="anonymous"
                 alt={`Ảnh bìa ${alt}`}
                 className="z-20 max-h-full max-w-full object-cover"
                 visibleByDefault
@@ -75,7 +74,6 @@ export default function MoeMangaCover({
         )}
         placeholderSrc={placeholder}
         src={thumbnailCoverUrl}
-        crossOrigin="anonymous"
         alt={`Ảnh bìa ${alt}`}
         className={cn("block h-auto w-full rounded-sm", className)}
         onLoad={() => setLoaded(true)}

--- a/src/app/(suicaodex)/(home)/_components/latest-update/latest-manga-card.tsx
+++ b/src/app/(suicaodex)/(home)/_components/latest-update/latest-manga-card.tsx
@@ -40,7 +40,6 @@ export default function LatestMangaCard({ chapter }: LatestMangaCardProps) {
           <LazyLoadImage
             wrapperClassName="block! w-full h-full absolute inset-0"
             src={coverUrl}
-            crossOrigin="anonymous"
             alt={title}
             placeholderSrc="/images/place-doro.webp"
             className="w-full h-full object-cover"

--- a/src/app/(suicaodex)/(home)/_components/moetruyen-section/index.tsx
+++ b/src/app/(suicaodex)/(home)/_components/moetruyen-section/index.tsx
@@ -148,7 +148,6 @@ function RotatingBackground({
           >
             <LazyLoadImage
               src={coverUrl}
-              crossOrigin="anonymous"
               alt={manga.title}
               wrapperClassName="block! absolute inset-0 h-full w-full overflow-hidden rounded-md"
               placeholderSrc={FALLBACK_COVER}

--- a/src/app/(suicaodex)/(manga)/manga/_components/manga-card.tsx
+++ b/src/app/(suicaodex)/(manga)/manga/_components/manga-card.tsx
@@ -46,7 +46,6 @@ export default function MangaCard({
             "h-auto w-full rounded-sm block object-cover aspect-5/7",
           )}
           src={cover_url}
-          crossOrigin="anonymous"
           alt={`Ảnh bìa ${title}`}
           onLoad={() => setLoaded(true)}
           onError={(e) => {

--- a/src/app/(suicaodex)/(manga)/manga/_components/manga-cover.tsx
+++ b/src/app/(suicaodex)/(manga)/manga/_components/manga-cover.tsx
@@ -81,7 +81,6 @@ export default function MangaCover({
               </div>
               <img
                 src={cover_full}
-                crossOrigin="anonymous"
                 alt={`Ảnh bìa ${alt}`}
                 className="max-h-full max-w-full object-cover z-20"
                 fetchPriority="high"
@@ -103,7 +102,6 @@ export default function MangaCover({
         placeholderSrc={placeholder}
         className={cn("h-auto w-full rounded-sm block", className)}
         src={cover_url}
-        crossOrigin="anonymous"
         alt={`Ảnh bìa ${alt}`}
         onLoad={() => setLoaded(true)}
         visibleByDefault={preload}

--- a/src/app/(suicaodex)/(user)/history/_components/history-manga-card.tsx
+++ b/src/app/(suicaodex)/(user)/history/_components/history-manga-card.tsx
@@ -54,7 +54,6 @@ export default function HistoryMangaCard({
       <NoPrefetchLink href={mangaHref} className="shrink-0">
         <Image
           src={coverUrl}
-          crossOrigin="anonymous"
           alt={title}
           width={80}
           height={112}

--- a/src/app/(suicaodex)/(user)/my-library/_components/account-library-card.tsx
+++ b/src/app/(suicaodex)/(user)/my-library/_components/account-library-card.tsx
@@ -96,7 +96,6 @@ export default function AccountLibraryCard({
             placeholderSrc="/images/place-doro.webp"
             className="w-full h-auto aspect-5/7 object-cover rounded-sm"
             src={coverUrl}
-            crossOrigin="anonymous"
             alt={`Ảnh bìa ${displayTitle}`}
             onError={(e) => {
               e.currentTarget.src = "/images/xidoco.webp";

--- a/src/app/(suicaodex)/(user)/my-library/_components/library-manga-card.tsx
+++ b/src/app/(suicaodex)/(user)/my-library/_components/library-manga-card.tsx
@@ -34,7 +34,6 @@ export default function LibraryMangaCard({
             placeholderSrc="/images/place-doro.webp"
             className="w-full h-auto aspect-5/7 object-cover rounded-sm"
             src={coverUrl}
-            crossOrigin="anonymous"
             alt={`Ảnh bìa ${title}`}
             onError={(e) => {
               e.currentTarget.src = "/images/xidoco.webp";

--- a/src/components/search/compact-card-moetruyen.tsx
+++ b/src/components/search/compact-card-moetruyen.tsx
@@ -26,7 +26,6 @@ export default function CompactCardMoetruyen({
         <LazyLoadImage
           wrapperClassName="block! shrink-0"
           src={coverUrl}
-          crossOrigin="anonymous"
           alt={manga.title}
           placeholderSrc="/images/place-doro.webp"
           className="w-16! h-auto! aspect-5/7 object-cover! rounded-sm border"

--- a/src/components/search/compact-card-weebdex.tsx
+++ b/src/components/search/compact-card-weebdex.tsx
@@ -27,7 +27,6 @@ export default function CompactCardWeebdex({ manga }: CompactCardWeebdexProps) {
         <LazyLoadImage
           wrapperClassName="block! shrink-0"
           src={coverUrl}
-          crossOrigin="anonymous"
           alt={title}
           placeholderSrc="/images/place-doro.webp"
           className="w-16! h-auto! aspect-5/7 object-cover! rounded-sm border"

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -2,11 +2,13 @@
 /// <reference lib="esnext" />
 /// <reference lib="webworker" />
 import { defaultCache } from "@serwist/next/worker";
-import type { PrecacheEntry, SerwistGlobalConfig } from "serwist";
+import type {
+  PrecacheEntry,
+  RouteHandlerCallback,
+  SerwistGlobalConfig,
+} from "serwist";
 import {
-  CacheableResponsePlugin,
-  CacheFirst,
-  ExpirationPlugin,
+  CacheExpiration,
   NetworkOnly,
   Serwist,
 } from "serwist";
@@ -25,10 +27,10 @@ const SUICAODEX_COVER_CACHE_NAME = "suicaodex-cover-images";
 const TRUYEN_MOE_COVER_CACHE_NAME = "truyen-moe-cover-images";
 const LEGACY_COVER_CACHE_NAMES = ["moetruyen-cover-images"] as const;
 const DEFAULT_IMAGE_CACHE_NAMES = [
-  "next-image",
   "cross-origin",
   "static-image-assets",
 ] as const;
+const coverCacheExpirations = new Map<string, CacheExpiration>();
 
 function isSuicaodex512CoverUrl(url: URL) {
   return (
@@ -129,16 +131,57 @@ async function cleanupCoverCaches() {
   );
 }
 
-const coverCachePlugins = [
-  new CacheableResponsePlugin({
-    statuses: [200],
-  }),
-  new ExpirationPlugin({
-    maxEntries: COVER_CACHE_MAX_ENTRIES,
-    maxAgeSeconds: COVER_CACHE_MAX_AGE_SECONDS,
-    purgeOnQuotaError: true,
-  }),
-];
+function getCoverCacheExpiration(cacheName: string) {
+  let expiration = coverCacheExpirations.get(cacheName);
+
+  if (!expiration) {
+    expiration = new CacheExpiration(cacheName, {
+      maxEntries: COVER_CACHE_MAX_ENTRIES,
+      maxAgeSeconds: COVER_CACHE_MAX_AGE_SECONDS,
+    });
+    coverCacheExpirations.set(cacheName, expiration);
+  }
+
+  return expiration;
+}
+
+function createCorsCoverCacheHandler(cacheName: string): RouteHandlerCallback {
+  return async ({ request }) => {
+    const cache = await caches.open(cacheName);
+    const expiration = getCoverCacheExpiration(cacheName);
+    const cachedResponse = await cache.match(request.url);
+
+    if (cachedResponse && !(await expiration.isURLExpired(request.url))) {
+      await expiration.updateTimestamp(request.url);
+      void expiration.expireEntries();
+      return cachedResponse;
+    }
+
+    if (cachedResponse) {
+      await cache.delete(request.url);
+    }
+
+    try {
+      const corsRequest = new Request(request.url, {
+        credentials: "omit",
+        mode: "cors",
+        redirect: "follow",
+      });
+      const response = await fetch(corsRequest);
+
+      if (response.status === 200) {
+        await cache.put(request.url, response.clone());
+        await expiration.updateTimestamp(request.url);
+        void expiration.expireEntries();
+        return response;
+      }
+    } catch {
+      // Fall back to the original no-cors request so the image can still render.
+    }
+
+    return fetch(request);
+  };
+}
 
 const serwist = new Serwist({
   precacheEntries: self.__SW_MANIFEST,
@@ -148,29 +191,22 @@ const serwist = new Serwist({
   runtimeCaching: [
     {
       matcher: ({ request, url }) =>
-        request.mode === "cors" && isSuicaodex512CoverUrl(url),
-      handler: new CacheFirst({
-        cacheName: SUICAODEX_COVER_CACHE_NAME,
-        plugins: coverCachePlugins,
-      }),
+        request.destination === "image" && isSuicaodex512CoverUrl(url),
+      handler: createCorsCoverCacheHandler(SUICAODEX_COVER_CACHE_NAME),
     },
     {
       matcher: ({ request, url }) =>
-        request.mode === "cors" &&
+        request.destination === "image" &&
         url.protocol === "https:" &&
         url.hostname === "u.truyen.moe" &&
         url.pathname.startsWith("/uploads/covers/"),
-      handler: new CacheFirst({
-        cacheName: TRUYEN_MOE_COVER_CACHE_NAME,
-        plugins: coverCachePlugins,
-      }),
+      handler: createCorsCoverCacheHandler(TRUYEN_MOE_COVER_CACHE_NAME),
     },
-    // Chặn defaultCache của Serwist cache ảnh tối ưu Next và ảnh cross-origin
-    // ngoài các cover cache chủ đích ở trên; các cache này dễ phình rất lớn.
+    // Chặn defaultCache của Serwist cache ảnh cross-origin ngoài các cover
+    // cache chủ đích ở trên; vẫn cho phép cache ảnh tối ưu Next cùng origin.
     {
-      matcher: ({ request, sameOrigin, url }) =>
-        request.destination === "image" &&
-        (url.pathname === "/_next/image" || !sameOrigin),
+      matcher: ({ request, sameOrigin }) =>
+        request.destination === "image" && !sameOrigin,
       handler: new NetworkOnly(),
     },
     // Không cache API calls từ weebdex


### PR DESCRIPTION
## Summary
- keep /_next/image on Serwist default cache
- stop using crossOrigin on cover image elements so images keep rendering when Cloudflare serves a response without ACAO
- let the service worker try a separate CORS fetch for cover caching and fall back to the original no-cors image request when CORS is unavailable

## Verification
- targeted ESLint on changed files passed
- bun run build passed