### PR TITLE
fix(sw): stop caching truyen moe covers

### DIFF
--- a/src/sw.ts
+++ b/src/sw.ts
@@ -24,8 +24,10 @@ declare const self: ServiceWorkerGlobalScope;
 const COVER_CACHE_MAX_ENTRIES = 200;
 const COVER_CACHE_MAX_AGE_SECONDS = 7 * 24 * 60 * 60;
 const SUICAODEX_COVER_CACHE_NAME = "suicaodex-cover-images";
-const TRUYEN_MOE_COVER_CACHE_NAME = "truyen-moe-cover-images";
-const LEGACY_COVER_CACHE_NAMES = ["moetruyen-cover-images"] as const;
+const LEGACY_COVER_CACHE_NAMES = [
+  "moetruyen-cover-images",
+  "truyen-moe-cover-images",
+] as const;
 const DEFAULT_IMAGE_CACHE_NAMES = [
   "cross-origin",
   "static-image-assets",
@@ -92,17 +94,6 @@ async function pruneSuicaodexCoverCache(existingCacheNames: string[]) {
   );
 }
 
-async function pruneTruyenMoeCoverCache(existingCacheNames: string[]) {
-  await pruneCoverCache(
-    TRUYEN_MOE_COVER_CACHE_NAME,
-    existingCacheNames,
-    (url) =>
-      url.protocol === "https:" &&
-      url.hostname === "u.truyen.moe" &&
-      url.pathname.startsWith("/uploads/covers/"),
-  );
-}
-
 async function deleteOversizedCoverCache(
   cacheName: string,
   existingCacheNames: string[],
@@ -123,11 +114,9 @@ async function cleanupCoverCaches() {
   const existingCacheNames = await caches.keys();
 
   await pruneSuicaodexCoverCache(existingCacheNames);
-  await pruneTruyenMoeCoverCache(existingCacheNames);
-  await Promise.all(
-    [SUICAODEX_COVER_CACHE_NAME, TRUYEN_MOE_COVER_CACHE_NAME].map(
-      (cacheName) => deleteOversizedCoverCache(cacheName, existingCacheNames),
-    ),
+  await deleteOversizedCoverCache(
+    SUICAODEX_COVER_CACHE_NAME,
+    existingCacheNames,
   );
 }
 
@@ -194,16 +183,8 @@ const serwist = new Serwist({
         request.destination === "image" && isSuicaodex512CoverUrl(url),
       handler: createCorsCoverCacheHandler(SUICAODEX_COVER_CACHE_NAME),
     },
-    {
-      matcher: ({ request, url }) =>
-        request.destination === "image" &&
-        url.protocol === "https:" &&
-        url.hostname === "u.truyen.moe" &&
-        url.pathname.startsWith("/uploads/covers/"),
-      handler: createCorsCoverCacheHandler(TRUYEN_MOE_COVER_CACHE_NAME),
-    },
-    // Chặn defaultCache của Serwist cache ảnh cross-origin ngoài các cover
-    // cache chủ đích ở trên; vẫn cho phép cache ảnh tối ưu Next cùng origin.
+    // Chặn defaultCache của Serwist cache ảnh cross-origin ngoài cover
+    // SuicaoDex chủ đích ở trên; vẫn cho phép cache ảnh tối ưu Next cùng origin.
     {
       matcher: ({ request, sameOrigin }) =>
         request.destination === "image" && !sameOrigin,


### PR DESCRIPTION
## Summary
- stop runtime caching u.truyen.moe cover images while CORS is unavailable
- delete the existing truyen-moe-cover-images cache during service worker activation
- keep SuicaoDex .512.webp cover caching and same-origin /_next/image caching unchanged

## Verification
- bunx eslint --quiet src/sw.ts
- bun run build