### PR TITLE
[codex] link moetruyen scanlation groups

### DIFF
--- a/src/app/(moetruyen)/moetruyen/(moe_home)/_components/moe_latest-update/index.tsx
+++ b/src/app/(moetruyen)/moetruyen/(moe_home)/_components/moe_latest-update/index.tsx
@@ -41,7 +41,7 @@ export default function MoeLatestUpdate({
       limit: LIMIT,
       page,
       sort: "updated_at",
-      include: "stats",
+      include: "stats,groups",
     },
     {
       query: {

--- a/src/app/(moetruyen)/moetruyen/(moe_home)/_components/moe_latest-update/moe-latest-manga-card.tsx
+++ b/src/app/(moetruyen)/moetruyen/(moe_home)/_components/moe_latest-update/moe-latest-manga-card.tsx
@@ -4,9 +4,11 @@ import Link from "next/link";
 import { Clock, EyeIcon, MessagesSquare, Users } from "lucide-react";
 import { LazyLoadImage } from "react-lazy-load-image-component";
 
+import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import type { GetV2Manga200DataItem } from "@/lib/moetruyen/model";
 import { getMoetruyenThumbnailCoverUrl } from "@/lib/moetruyen/cover-url";
+import { getMoeGroupHref, getMoePrimaryGroup } from "@/lib/moetruyen/group-url";
 import { formatNumber, formatTimeToNow } from "@/lib/utils";
 import { VN } from "country-flag-icons/react/3x2";
 
@@ -19,6 +21,7 @@ export default function MoeLatestMangaCard({ manga }: MoeLatestMangaCardProps) {
     manga.coverUrl ?? "/images/no-cover.webp",
   );
   const mangaHref = `/moetruyen/manga/${manga.id}/${manga.slug}`;
+  const primaryGroup = getMoePrimaryGroup(manga.groups);
   const chapterLabel = manga.latestChapterNumber
     ? `Ch. ${manga.latestChapterNumber}`
     : manga.isOneshot
@@ -71,9 +74,26 @@ export default function MoeLatestMangaCard({ manga }: MoeLatestMangaCardProps) {
         <div className="space-y-1">
           <div className="flex items-center space-x-1 min-w-0">
             <Users size={16} className="shrink-0" />
-            <span className="text-xs font-normal truncate px-0.5">
-              {manga.groupName ?? "No Group"}
-            </span>
+            {primaryGroup ? (
+              <Button
+                asChild
+                variant="ghost"
+                className="whitespace-normal! font-normal text-start text-xs rounded-sm h-auto py-0 px-0.5 hover:text-primary line-clamp-1 break-all shrink! min-w-0"
+                size="sm"
+              >
+                <Link
+                  href={getMoeGroupHref(primaryGroup)}
+                  prefetch={false}
+                  className="truncate"
+                >
+                  {primaryGroup.name}
+                </Link>
+              </Button>
+            ) : (
+              <span className="text-xs font-normal truncate px-0.5">
+                No Group
+              </span>
+            )}
           </div>
 
           <div className="flex items-center space-x-1 min-w-0 justify-between">

--- a/src/app/(moetruyen)/moetruyen/(moe_home)/_components/moe_leaderboard/index.tsx
+++ b/src/app/(moetruyen)/moetruyen/(moe_home)/_components/moe_leaderboard/index.tsx
@@ -54,6 +54,7 @@ export default function MoeLeaderboard() {
       limit: 10,
       sort_by: activeSort,
       time: activeTime,
+      include: "groups",
     },
     {
       query: {

--- a/src/app/(moetruyen)/moetruyen/(moe_home)/_components/moe_leaderboard/moe-leaderboard-item.tsx
+++ b/src/app/(moetruyen)/moetruyen/(moe_home)/_components/moe_leaderboard/moe-leaderboard-item.tsx
@@ -7,6 +7,7 @@ import { LazyLoadImage } from "react-lazy-load-image-component";
 
 import { Card } from "@/components/ui/card";
 import { getMoetruyenThumbnailCoverUrl } from "@/lib/moetruyen/cover-url";
+import { getMoeGroupHref, getMoePrimaryGroup } from "@/lib/moetruyen/group-url";
 import type { GetV2MangaTop200DataItem } from "@/lib/moetruyen/model";
 import { formatNumber } from "@/lib/utils";
 
@@ -32,15 +33,21 @@ export default function MoeLeaderboardItem({
     w: 256,
     q: 80,
   });
+  const primaryGroup = getMoePrimaryGroup(manga.groups);
   const RankingIcon = RANKING_ICON_MAP[manga.ranking.sortBy] ?? Eye;
 
   return (
-    <Card className="overflow-hidden rounded-md border-none shadow-xs transition-colors duration-200 min-h-[121px]">
+    <Card className="relative overflow-hidden rounded-md border-none shadow-xs transition-colors duration-200 min-h-[121px]">
       <Link
         href={href}
         prefetch={false}
-        className="flex items-center gap-3 p-3"
+        aria-label={manga.title}
+        className="absolute inset-0 z-0 rounded-md"
       >
+        <span className="sr-only">{manga.title}</span>
+      </Link>
+
+      <div className="relative z-10 flex items-center gap-3 p-3 pointer-events-none">
         <div className="flex h-24 w-10 shrink-0 items-center justify-center rounded-md bg-muted text-2xl font-black text-primary">
           {manga.ranking.rank}
         </div>
@@ -64,7 +71,17 @@ export default function MoeLeaderboardItem({
           </p>
 
           <p className="mt-1 line-clamp-1 text-sm text-muted-foreground">
-            {manga.groupName ?? "No Group"}
+            {primaryGroup ? (
+              <Link
+                href={getMoeGroupHref(primaryGroup)}
+                prefetch={false}
+                className="pointer-events-auto hover:text-primary hover:underline"
+              >
+                {primaryGroup.name}
+              </Link>
+            ) : (
+              "No Group"
+            )}
           </p>
 
           <div className="mt-2 flex items-center justify-end gap-2 text-sm text-muted-foreground">
@@ -76,7 +93,7 @@ export default function MoeLeaderboardItem({
             </span>
           </div>
         </div>
-      </Link>
+      </div>
     </Card>
   );
 }

--- a/src/app/(moetruyen)/moetruyen/(moe_home)/manga/_components/moe-manga-chapters-list.tsx
+++ b/src/app/(moetruyen)/moetruyen/(moe_home)/manga/_components/moe-manga-chapters-list.tsx
@@ -3,6 +3,7 @@
 import NoPrefetchLink from "@/components/common/no-prefetch-link";
 import PaginationControl from "@/components/common/pagination-control";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import {
   Empty,
@@ -17,6 +18,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useGetV2MangaByIdChapters } from "@/lib/moetruyen/hooks/manga/manga";
+import { getMoeGroupHref } from "@/lib/moetruyen/group-url";
 import type { GetV2MangaByIdChapters200DataChaptersItem } from "@/lib/moetruyen/model/getV2MangaByIdChapters200DataChaptersItem";
 import { cn, formatNumber, formatTimeToNow } from "@/lib/utils";
 import {
@@ -61,7 +63,7 @@ function MoeChapterCard({
   const timestamp = chapter.date;
   const chapterText = `${getChapterLabel(chapter)}${chapter.title ? ` - ${chapter.title}` : ""}`;
   const accessLabel = getAccessLabel(chapter.access);
-  const groupName = chapter.groupName?.trim();
+  const groups = chapter.groups ?? [];
   const card = (
     <Card
       aria-disabled={isUnavailable}
@@ -72,7 +74,19 @@ function MoeChapterCard({
         isUnavailable && "cursor-not-allowed text-muted-foreground opacity-90",
       )}
     >
-      <div className="flex items-center gap-2">
+      {isUnavailable ? null : (
+        <NoPrefetchLink
+          suppressHydrationWarning
+          href={`/moetruyen/chapter/${chapter.id}`}
+          target="_self"
+          aria-label={chapterText}
+          className="absolute inset-0 z-0"
+        >
+          <span className="sr-only">{chapterText}</span>
+        </NoPrefetchLink>
+      )}
+
+      <div className="relative z-10 flex items-center gap-2 pointer-events-none">
         <div className="flex min-w-0 flex-auto items-center space-x-2">
           {isUnavailable ? (
             <EyeOff className="size-4 shrink-0 text-muted-foreground" />
@@ -116,13 +130,31 @@ function MoeChapterCard({
         ) : null}
       </div>
 
-      <div className="flex items-center gap-2">
+      <div className="relative z-10 flex items-center gap-2 pointer-events-none">
         <div className="flex min-w-0 flex-auto items-center space-x-1">
           <Users size={16} className="shrink-0" />
 
-          <span className="line-clamp-1 px-1 text-sm font-normal">
-            {groupName ?? "No Group"}
-          </span>
+          {groups.length === 0 ? (
+            <span className="line-clamp-1 px-1 text-sm font-normal">
+              No Group
+            </span>
+          ) : (
+            <div className="flex min-w-0 items-center space-x-1">
+              {groups.map((group) => (
+                <Button
+                  asChild
+                  key={group.id}
+                  variant="ghost"
+                  className="pointer-events-auto whitespace-normal! shrink! font-normal text-start text-sm line-clamp-1 rounded-sm h-auto! py-0! px-1! hover:underline hover:text-primary break-all"
+                  size="sm"
+                >
+                  <NoPrefetchLink href={getMoeGroupHref(group)}>
+                    {group.name}
+                  </NoPrefetchLink>
+                </Button>
+              ))}
+            </div>
+          )}
         </div>
 
         {chapter.pages || accessLabel ? (
@@ -166,15 +198,7 @@ function MoeChapterCard({
     );
   }
 
-  return (
-    <NoPrefetchLink
-      suppressHydrationWarning
-      href={`/moetruyen/chapter/${chapter.id}`}
-      target="_self"
-    >
-      {card}
-    </NoPrefetchLink>
-  );
+  return card;
 }
 
 export default function MoeMangaChaptersList({

--- a/src/app/(moetruyen)/moetruyen/(moe_reader)/_components/moe-reader-sidebar.tsx
+++ b/src/app/(moetruyen)/moetruyen/(moe_reader)/_components/moe-reader-sidebar.tsx
@@ -23,6 +23,7 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import NoPrefetchLink from "@/components/common/no-prefetch-link";
+import { getMoeGroupHref } from "@/lib/moetruyen/group-url";
 import { cn } from "@/lib/utils";
 import type { GetV2ChaptersById200Data } from "@/lib/moetruyen/model/getV2ChaptersById200Data";
 import {
@@ -56,7 +57,7 @@ export default function MoeReaderSidebar({
   ...props
 }: MoeReaderSidebarProps) {
   const { state, isMobile, toggleSidebar } = useSidebar();
-  const groupName = chapter.chapter.groupName?.trim();
+  const groups = chapter.chapter.groups ?? [];
 
   return (
     <Sidebar collapsible="icon" {...props}>
@@ -132,8 +133,11 @@ export default function MoeReaderSidebar({
           <Collapsible asChild defaultOpen className="group/collapsible">
             <SidebarMenuItem>
               <CollapsibleTrigger asChild>
-                <SidebarMenuButton tooltip="Nhóm dịch" disabled={!groupName}>
-                  {groupName ? (
+                <SidebarMenuButton
+                  tooltip="Nhóm dịch"
+                  disabled={groups.length === 0}
+                >
+                  {groups.length > 0 ? (
                     <>
                       <UsersIcon />
                       <span>Nhóm dịch</span>
@@ -147,14 +151,21 @@ export default function MoeReaderSidebar({
                 </SidebarMenuButton>
               </CollapsibleTrigger>
 
-              {groupName ? (
+              {groups.length > 0 ? (
                 <CollapsibleContent>
                   <SidebarMenuSub>
-                    <SidebarMenuSubItem>
-                      <SidebarMenuSubButton className="h-auto w-fit whitespace-normal! text-primary hover:bg-transparent hover:text-primary hover:underline">
-                        {groupName}
-                      </SidebarMenuSubButton>
-                    </SidebarMenuSubItem>
+                    {groups.map((group) => (
+                      <SidebarMenuSubItem key={group.id}>
+                        <SidebarMenuSubButton
+                          asChild
+                          className="h-auto w-fit whitespace-normal! text-primary hover:bg-transparent hover:text-primary hover:underline"
+                        >
+                          <NoPrefetchLink href={getMoeGroupHref(group)}>
+                            {group.name}
+                          </NoPrefetchLink>
+                        </SidebarMenuSubButton>
+                      </SidebarMenuSubItem>
+                    ))}
                   </SidebarMenuSub>
                 </CollapsibleContent>
               ) : null}

--- a/src/lib/moetruyen/group-url.ts
+++ b/src/lib/moetruyen/group-url.ts
@@ -1,0 +1,16 @@
+import { generateSlug } from "@/lib/utils";
+
+export interface MoeGroupSummary {
+  id: number;
+  name: string;
+}
+
+export function getMoeGroupHref(group: MoeGroupSummary) {
+  return `/moetruyen/group/${group.id}/${generateSlug(group.name)}`;
+}
+
+export function getMoePrimaryGroup(
+  groups?: readonly MoeGroupSummary[] | null,
+) {
+  return groups?.[0] ?? null;
+}

--- a/tests/moetruyen/group-url.test.ts
+++ b/tests/moetruyen/group-url.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { getMoeGroupHref, getMoePrimaryGroup } from "@/lib/moetruyen/group-url";
+
+void describe("MoeTruyen group URLs", () => {
+  void it("builds the internal group detail URL with a generated slug", () => {
+    assert.equal(
+      getMoeGroupHref({
+        id: 107,
+        name: "Lữ đoàn bóng ma (uploader)",
+      }),
+      "/moetruyen/group/107/lu-doan-bong-ma-uploader",
+    );
+  });
+
+  void it("uses the first resolved group as the primary group", () => {
+    const primaryGroup = getMoePrimaryGroup([
+      { id: 8, name: "IA Translation" },
+      { id: 107, name: "Lữ đoàn bóng ma (uploader)" },
+    ]);
+
+    assert.deepEqual(primaryGroup, { id: 8, name: "IA Translation" });
+  });
+});


### PR DESCRIPTION
## Summary
- Link MoeTruyen scanlation group names to the existing `/moetruyen/group/[id]/[slug]` route.
- Request `groups` expansions where home/latest and leaderboard cards need group ids.
- Render all available groups in manga chapter rows and the reader sidebar, matching the Suicaodex behavior.

## Validation
- `bun run test:file tests/moetruyen/group-url.test.ts`
- `bunx eslint --quiet "src/app/(moetruyen)/moetruyen/(moe_home)/_components/moe_latest-update/index.tsx" "src/app/(moetruyen)/moetruyen/(moe_home)/_components/moe_latest-update/moe-latest-manga-card.tsx" "src/app/(moetruyen)/moetruyen/(moe_home)/_components/moe_leaderboard/index.tsx" "src/app/(moetruyen)/moetruyen/(moe_home)/_components/moe_leaderboard/moe-leaderboard-item.tsx" "src/app/(moetruyen)/moetruyen/(moe_home)/manga/_components/moe-manga-chapters-list.tsx" "src/app/(moetruyen)/moetruyen/(moe_reader)/_components/moe-reader-sidebar.tsx" "src/lib/moetruyen/group-url.ts" "tests/moetruyen/group-url.test.ts"`
- `bunx tsc --noEmit --pretty false`
- `bun run test`

Note: full `bun run lint` still reports existing repository-wide issues outside this change, including `orval.config.ts` nullish-coalescing errors and many CRLF Prettier warnings.